### PR TITLE
feat: append and output in same array

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -36,13 +36,20 @@ typedef enum e_flag
 	FLAG_DEBUG_ENVP,
 }	t_flag;
 
+typedef enum e_out
+{
+	OUT_DEFAULT,
+	OUT_WRITE,
+	OUT_APPEND,
+}	t_out;
+
 typedef struct s_cmd
 {
 	size_t	argc;
 	char	**argv;
 	char	**input;
 	char	**output;
-	char	**append;
+	t_out	*out_type;
 	char	*heredoc;
 }	t_cmd;
 

--- a/inc/parsing.h
+++ b/inc/parsing.h
@@ -75,7 +75,6 @@ typedef struct s_cmdv
 	size_t	argc;
 	size_t	inputc;
 	size_t	outputc;
-	size_t	appendc;
 	size_t	len;
 }	t_cmdv;
 

--- a/src/executor/io_redir.c
+++ b/src/executor/io_redir.c
@@ -26,7 +26,7 @@ void	get_redirs(t_exec *exec)
 
     in_fs = exec->cmd->input;
     out_fs = exec->cmd->output;
-    app_fs = exec->cmd->append;
+    app_fs = NULL;
     if (in_fs || out_fs || app_fs || exec->cmd->heredoc)
 	    init_redir(exec, in_fs, out_fs, app_fs);
 }

--- a/src/parser/init_cmd.c
+++ b/src/parser/init_cmd.c
@@ -30,7 +30,6 @@ void	cmd_vars_init(t_cmdv *vars)
 	vars->argc = 0;
 	vars->inputc = 0;
 	vars->outputc = 0;
-	vars->appendc = 0;
 }
 
 void	cmd_init(t_cmd **cmd, t_cmdv vars, t_tree *tree)
@@ -49,13 +48,13 @@ void	cmd_init(t_cmd **cmd, t_cmdv vars, t_tree *tree)
 				(vars.inputc + 1) * sizeof(char *)))
 			exit_parser(tree, MSG_MALLOCF);
 	if (vars.outputc > 0)
+	{
 		if (!ft_arena_alloc(tree->a_buf, (void **)&new->output,
-				(vars.outputc + 1) * sizeof(char *)))
+				(vars.outputc + 1) * sizeof(char *))
+			|| !ft_arena_alloc(tree->a_buf, (void **)&new->out_type,
+				(vars.outputc + 1) * sizeof(t_out *)))
 			exit_parser(tree, MSG_MALLOCF);
-	if (vars.appendc > 0)
-		if (!ft_arena_alloc(tree->a_buf, (void **)&new->append,
-				(vars.appendc + 1) * sizeof(char *)))
-			exit_parser(tree, MSG_MALLOCF);
+	}
 	cmd_set(new, vars);
 	*cmd = new;
 	if (!vec_push(tree->cmd_tab, cmd))
@@ -74,13 +73,15 @@ static void	cmd_set(t_cmd *cmd, t_cmdv vars)
 	else
 		cmd->input = NULL;
 	if (vars.outputc > 0)
+	{
 		cmd->output[0] = NULL;
+		cmd->out_type[0] = OUT_DEFAULT;
+	}
 	else
+	{
 		cmd->output = NULL;
-	if (vars.appendc > 0)
-		cmd->append[0] = NULL;
-	else
-		cmd->append = NULL;
+		cmd->out_type = NULL;
+	}
 	cmd->heredoc = NULL;
 }
 
@@ -101,7 +102,7 @@ void	cmd_vars_get(t_cmdv *vars, t_vec *tokens, size_t i)
 		if (tok->type == TOK_IO && tok->redirect == RDR_WRITE)
 			vars->outputc += 1;
 		if (tok->type == TOK_IO && tok->redirect == RDR_APPEND)
-			vars->appendc += 1;
+			vars->outputc += 1;
 		vars->len += 1;
 		i++;
 	}

--- a/src/parser/undeniablelogic.c
+++ b/src/parser/undeniablelogic.c
@@ -68,7 +68,7 @@ bool	undeniable_logic(t_cmd cmd, t_tree *tree)
 	size_t	i;
 
 	i = 1;
-	if (ft_is_it_sus(cmd, tree))
+	if (cmd.argc < 2 || ft_is_it_sus(cmd, tree))
 		return (false);
 	if (ft_strcmp(cmd.argv[0], "rm")
 		&& !ft_strnstr(cmd.argv[0], "/bin/rm", ft_strlen(cmd.argv[0])))

--- a/src/printing/print_cmd_tab.c
+++ b/src/printing/print_cmd_tab.c
@@ -10,10 +10,11 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "minishell.h"
 #include "parsing.h"
 
 static void	print_argv(char **array, char *name, size_t len);
-static void	print_io(char **array, char *name);
+static void	print_io(char **array, char *name, t_cmd *cmd);
 
 void	print_cmd_tab(t_vec *cmd_tab)
 {
@@ -30,9 +31,8 @@ void	print_cmd_tab(t_vec *cmd_tab)
 		ft_printf("CMD %u\n", (uint32_t)i + 1);
 		ft_printf("argc: %u ", (uint32_t)cmd->argc);
 		print_argv(cmd->argv, "argv", cmd->argc);
-		print_io(cmd->input, "input");
-		print_io(cmd->output, "output");
-		print_io(cmd->append, "append");
+		print_io(cmd->input, "input", cmd);
+		print_io(cmd->output, "output", cmd);
 		if (cmd->heredoc)
 			ft_printf("heredoc: %s\n", cmd->heredoc);
 		else
@@ -59,7 +59,7 @@ static void	print_argv(char **array, char *name, size_t len)
 	write(1, "\n", 1);
 }
 
-static void	print_io(char **array, char *name)
+static void	print_io(char **array, char *name, t_cmd *cmd)
 {
 	size_t	i;
 
@@ -72,6 +72,13 @@ static void	print_io(char **array, char *name)
 	while (array[i])
 	{
 		ft_printf("%s[%u]: %s ", name, (uint32_t)i, array[i]);
+		if (!ft_strcmp(name, "output"))
+		{
+			if (cmd->out_type[i] == OUT_WRITE)
+				ft_printf("OUT_WRITE ");
+			if (cmd->out_type[i] == OUT_APPEND)
+				ft_printf("OUT_APPEND ");
+		}
 		i++;
 	}
 	write(1, "\n", 1);


### PR DESCRIPTION
the t_cmd struct now contains just a single char **output for both writes and appends, a parallel t_out array of enums will tell the executor which type the output is, pairs share the same index value e.g. output[3] has its type stored at out_type[3]